### PR TITLE
Update chips-biannual-technology-update-2022-1.md

### DIFF
--- a/content/events/chips-biannual-technology-update-2022-1.md
+++ b/content/events/chips-biannual-technology-update-2022-1.md
@@ -1,7 +1,7 @@
 ---
 title: CHIPS Alliance First 2022 Biannual Technology Update
 date: 2022-04-19
-external_url: https://events.linuxfoundation.org/chips-biannual-technology-update/
+external_url: 
 ---
 
 Check out the presentations below:


### PR DESCRIPTION
Removed external link that pointed to December 2022 event. as this is for the April event.