### PR TITLE
Multi-branch deployments

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: gh-pages
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -5,6 +5,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  pull_request:
 
 jobs:
   deploy:
@@ -34,8 +35,18 @@ jobs:
           # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data
           cache-dependency-path: '**/package-lock.json'
 
+      - name: Get PR metadata
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        if: github.event_name == 'pull_request'
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+        id: PR
+
       - run: npm ci
       - run: hugo --minify --baseURL https://${{ github.repository_owner }}.github.io/$( echo ${{ github.repository }} | cut -d/ -f 2)/
+        if: ${{ github.ref == 'refs/heads/main' }}
+      - run: hugo --minify --baseURL https://${{ github.repository_owner }}.github.io/$( echo ${{ github.repository }} | cut -d/ -f 2)/preview/${{ steps.PR.outputs.number }}/
+        if: github.event_name == 'pull_request'
       - run: cp -a static public
 
       - name: Deploy
@@ -44,3 +55,16 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+
+      # prepare metadata and upload artifacts for multi branch deployment
+      - name: Move deployment to the correct preview directory
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir preview/
+          mv ./public preview/${{ steps.PR.outputs.number}}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: pr_deployment
+          path: ./preview/

--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    concurrency:
+      group: gh-pages
     name: Deploy PR preview
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/preview_deploy.yml
+++ b/.github/workflows/preview_deploy.yml
@@ -1,0 +1,49 @@
+on:
+  workflow_run:
+    workflows: ["Deploy Hugo site to Pages"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    name: Deploy PR preview
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download current deployment
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: ./public
+      - name: Download artifacts
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_deployment"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            console.log("::set-output name=artifact_id::" + matchArtifact.id);
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr_deployment.zip', Buffer.from(download.data));
+
+      - name: Unpack artifacts
+        run: |
+          unzip pr_deployment.zip -d ./public/preview
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
To deploy the website preview from PRs (including PRs from forks), the deployment needs to come from the main branch (otherwise the action will not have enough privileges to push, this is to prevent random people from changing the deployment scripts with a PR).

To achieve proper and safe PR deployments, we need to:
* Generate the website in PRs, upload it as artifacts
* From the context of the default branch (with privileges), download the artifacts and deploy them to a for example a subdirectory