### PR TITLE
Update preview_remove.yml

### DIFF
--- a/.github/workflows/preview_remove.yml
+++ b/.github/workflows/preview_remove.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          commit_message: Remove the preview of \#${{ github.event.number }}
+          commit_message: "Remove the preview of #${{ github.event.number }}"
           cname: www.chipsalliance.org


### PR DESCRIPTION
Use quotes instead of the backslash.
The backslash escapes the hash but still appears in the commit message, which is not what we want.