### PR TITLE
`Extract the commenter to a separate job

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency:
       group: gh-pages
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -83,9 +81,3 @@ jobs:
         with:
           name: pr_deployment
           path: ./preview/
-      - name: Add comment with preview Link
-        uses: mshick/add-pr-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          message: |
-            Deploying preview to https://chipsalliance.org/preview/${{ steps.PR.outputs.number }}/

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,24 @@
+name: Add preview link
+
+on:
+  pull_request:
+
+jobs:
+  comment:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Get PR metadata
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        if: github.event_name == 'pull_request'
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+        id: PR
+
+      - name: Add comment with preview Link
+        uses: mshick/add-pr-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          message: |
+            Deploying preview to https://chipsalliance.org/preview/${{ steps.PR.outputs.number }}/


### PR DESCRIPTION
Otherwise we have to set up permissions globally which is not optimal.